### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs_player.yml
+++ b/.github/workflows/nodejs_player.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI player
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sparkoo/csgo-2d-demo-viewer/security/code-scanning/6](https://github.com/sparkoo/csgo-2d-demo-viewer/security/code-scanning/6)

To fix the problem, an explicit `permissions` block specifying the least privileges necessary should be added to the workflow. For this workflow, which only checks out source code, sets up Node, installs dependencies, and runs builds, the only required permission is to read repository contents. No write permissions are needed for issues, pull requests, etc.  
The fix involves adding:

- The following under the root-level keys (directly after `name:` and before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
This will restrict all jobs in this workflow to only have read access to repository contents, unless a job specifically overrides it with its own `permissions` block.  
No additional imports, methods, or variable definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
