### PR TITLE
Remove Umami analytics integration

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -31,8 +31,6 @@ jobs:
         run: npm run build
         working-directory: web
         env:
-          VITE_UMAMI_SCRIPT_URL: ${{ secrets.VITE_UMAMI_SCRIPT_URL }}
-          VITE_UMAMI_WEBSITE_ID: ${{ secrets.VITE_UMAMI_WEBSITE_ID }}
           VITE_WASM_BASE_URL: ${{ secrets.VITE_WASM_BASE_URL }}
           VITE_DOWNLOAD_SERVER_URL: ${{ secrets.VITE_DOWNLOAD_SERVER_URL }}
 

--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,6 @@
     <link rel="stylesheet" href="/style.css" />
     <link rel="manifest" href="/manifest.json" />
     <title>CS2 2D Replay</title>
-    <!-- UMAMI_ANALYTICS_PLACEHOLDER -->
   </head>
 
   <body>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,21 +3,6 @@ import preact from "@preact/preset-vite";
 import fs from "fs";
 import path from "path";
 
-// Replaces <!-- UMAMI_ANALYTICS_PLACEHOLDER --> in index.html at build time.
-// When env vars are not set the placeholder is simply removed.
-function analyticsPlugin(scriptURL, websiteID) {
-  return {
-    name: "inject-analytics",
-    transformIndexHtml(html) {
-      const script =
-        scriptURL && websiteID
-          ? `<script defer src="${scriptURL}" data-website-id="${websiteID}"></script>`
-          : "";
-      return html.replace("<!-- UMAMI_ANALYTICS_PLACEHOLDER -->", script);
-    },
-  };
-}
-
 // Replaces __WASM_BASE_URL__ in the built worker.js with VITE_WASM_BASE_URL.
 // worker.js lives in public/ so Vite copies it as-is; we patch it after the
 // bundle is written.  Empty string is fine: the worker then uses relative paths
@@ -56,7 +41,6 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       preact(),
-      analyticsPlugin(env.VITE_UMAMI_SCRIPT_URL, env.VITE_UMAMI_WEBSITE_ID),
       wasmBaseURLPlugin(
         (() => {
           const u = env.VITE_WASM_BASE_URL || "";


### PR DESCRIPTION
## Summary
This PR removes the Umami analytics integration from the project, including the custom Vite plugin that injected analytics scripts and all related environment variable configuration.

## Key Changes
- Removed `analyticsPlugin()` function from `web/vite.config.js` that was responsible for injecting Umami analytics scripts into the HTML
- Removed the analytics plugin from the Vite plugins array in the build configuration
- Removed `VITE_UMAMI_SCRIPT_URL` and `VITE_UMAMI_WEBSITE_ID` environment variables from the Firebase deployment workflow
- Removed the `<!-- UMAMI_ANALYTICS_PLACEHOLDER -->` comment from `web/index.html`

## Implementation Details
The analytics plugin was a custom Vite plugin that would replace a placeholder comment in `index.html` with an analytics script tag at build time. By removing this plugin and its configuration, the application no longer includes any Umami analytics tracking.

https://claude.ai/code/session_01CuGUqcfPBZTas9mBTaE6vv