### PR TITLE
Add auto-fetch demo URL feature for CS2 demo viewer

### DIFF
--- a/browserplugin/faceit/background.js
+++ b/browserplugin/faceit/background.js
@@ -1,26 +1,78 @@
 import browser from "webextension-polyfill";
 
+// Fetch the signed demo download URL from the Faceit API using the user's
+// session cookies. The background service worker can make credentialed
+// cross-origin requests to any host listed in host_permissions, so Faceit
+// auth cookies are attached automatically when credentials: 'include' is set.
+// NOTE: the two-step API call sequence here is intentionally shared with
+// fetchDemoUrlDirect in content-script.js and fetchMatchDemo in
+// intercept-page.js — all three serve different execution contexts.
+async function fetchDemoUrlFromBackground(matchId) {
+  const matchRes = await fetch(
+    `https://www.faceit.com/api/match/v2/match/${matchId}`,
+    { credentials: "include" }
+  );
+  if (!matchRes.ok) throw new Error(`match API ${matchRes.status}`);
+  const matchData = await matchRes.json();
+  const demoUrl = matchData?.payload?.demoURLs?.[0];
+  if (!demoUrl) throw new Error("no demoURL in match payload");
+
+  const dlRes = await fetch(
+    "https://www.faceit.com/api/download/v2/demos/download-url",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resource_url: demoUrl }),
+      credentials: "include",
+    }
+  );
+  if (!dlRes.ok) throw new Error(`download API ${dlRes.status}`);
+  const dlData = await dlRes.json();
+  const dlUrl = dlData?.payload?.download_url;
+  if (!dlUrl) throw new Error("no download_url in payload");
+  return dlUrl;
+}
+
 // Inject intercept-page.js into the page's MAIN world so it can patch
 // window.fetch / window.open in the same JS context as Faceit's own code.
 // Injection happens on demand (user click), not before page load.
 // chrome.scripting.executeScript bypasses CSP — unlike a <script src> tag.
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type !== "injectInterceptor") return;
+  if (message.type === "injectInterceptor") {
+    const tabId = sender.tab?.id;
+    if (typeof tabId !== "number") {
+      sendResponse({ ok: false, error: "no tab id" });
+      return;
+    }
 
-  const tabId = sender.tab?.id;
-  if (typeof tabId !== "number") {
-    sendResponse({ ok: false, error: "no tab id" });
-    return;
+    browser.scripting
+      .executeScript({
+        target: { tabId },
+        files: ["intercept-page.js"],
+        world: "MAIN",
+      })
+      .then(() => sendResponse({ ok: true }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+
+    return true; // keep message channel open for the async response
   }
 
-  browser.scripting
-    .executeScript({
-      target: { tabId },
-      files: ["intercept-page.js"],
-      world: "MAIN",
-    })
-    .then(() => sendResponse({ ok: true }))
-    .catch((err) => sendResponse({ ok: false, error: String(err) }));
+  if (message.type === "autoFetchDemoUrl") {
+    // Called by viewer-content-script.js when the viewer page is opened with
+    // ?faceit_match_id=<id>. Fetches the signed CDN URL from Faceit using the
+    // user's session cookies and returns it so the content script can redirect.
+    const { matchId } = message;
+    fetchDemoUrlFromBackground(matchId)
+      .then((dlUrl) => {
+        if (new URL(dlUrl).protocol !== "https:")
+          throw new Error("invalid protocol");
+        sendResponse({ dlUrl });
+      })
+      .catch((err) => {
+        console.warn("[Auto-fetch] Failed:", err.message);
+        sendResponse({ error: err.message });
+      });
 
-  return true; // keep message channel open for the async response
+    return true; // keep message channel open for the async response
+  }
 });

--- a/browserplugin/faceit/manifest.json
+++ b/browserplugin/faceit/manifest.json
@@ -18,13 +18,20 @@
   "host_permissions": [
     "https://www.faceit.com/*",
     "https://faceit.com/*",
-    "https://*.faceit.com/*"
+    "https://*.faceit.com/*",
+    "https://2d.sparko.cz/*"
   ],
   "content_scripts": [
     {
       "matches": ["https://www.faceit.com/*", "https://faceit.com/*"],
       "js": ["content-script.js"],
       "css": ["content-styles.css"],
+      "run_at": "document_end",
+      "all_frames": false
+    },
+    {
+      "matches": ["https://2d.sparko.cz/player*"],
+      "js": ["viewer-content-script.js"],
       "run_at": "document_end",
       "all_frames": false
     }

--- a/browserplugin/faceit/viewer-content-script.js
+++ b/browserplugin/faceit/viewer-content-script.js
@@ -1,0 +1,39 @@
+// CS2 Demo Viewer - Viewer Page Auto-Load Content Script
+// Runs on the 2D demo viewer page (2d.sparko.cz/player).
+// When the page is opened with ?faceit_match_id=<id>, automatically fetches
+// the signed demo download URL from the Faceit API (via the background service
+// worker which has access to the user's Faceit session cookies) and redirects
+// to ?demourl=<url> to start playback immediately.
+import browser from "webextension-polyfill";
+
+const MATCH_ID_RE =
+  /^\d+-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+(async () => {
+  const params = new URLSearchParams(window.location.search);
+  const matchId = params.get("faceit_match_id");
+  if (!matchId || !MATCH_ID_RE.test(matchId)) return;
+
+  console.log("[CS2 Extension] Auto-fetching demo URL for match:", matchId);
+
+  try {
+    const result = await browser.runtime.sendMessage({
+      type: "autoFetchDemoUrl",
+      matchId,
+    });
+
+    if (result?.dlUrl) {
+      console.log("[CS2 Extension] Got demo URL, redirecting...");
+      window.location.replace(
+        `/player?demourl=${encodeURIComponent(result.dlUrl)}`
+      );
+    } else if (result?.error) {
+      console.warn("[CS2 Extension] Auto-fetch error:", result.error);
+      // Viewer will show its own dialog as fallback
+    }
+  } catch (err) {
+    // Extension context unavailable or background unreachable — fail silently
+    // so the viewer's built-in Faceit dialog is shown as a fallback.
+    console.log("[CS2 Extension] Auto-fetch unavailable:", err.message);
+  }
+})();

--- a/browserplugin/faceit/webpack.config.js
+++ b/browserplugin/faceit/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = (env) => {
   return {
     entry: {
       "content-script": "./content-script.js",
+      "viewer-content-script": "./viewer-content-script.js",
       popup: "./popup.js",
       background: "./background.js",
     },


### PR DESCRIPTION
## Summary
This PR adds automatic demo URL fetching functionality for the CS2 demo viewer page (2d.sparko.cz/player). When users open the viewer with a `?faceit_match_id=<id>` parameter, the extension now automatically fetches the signed CDN download URL from the Faceit API and redirects to start playback immediately, eliminating the need for manual URL entry.

## Key Changes
- **New content script** (`viewer-content-script.js`): Runs on the demo viewer page and handles auto-fetching logic
  - Validates the match ID format using regex pattern matching
  - Sends a message to the background service worker to fetch the signed demo URL
  - Automatically redirects to the viewer with the demo URL parameter on success
  - Falls back gracefully to the viewer's built-in dialog if auto-fetch fails
  
- **Enhanced background service worker** (`background.js`):
  - Extracted demo URL fetching logic into a new `fetchDemoUrlFromBackground()` function
  - Added handler for `autoFetchDemoUrl` message type that leverages the background worker's credentialed cross-origin request capabilities
  - Validates the returned download URL protocol to ensure HTTPS
  
- **Updated manifest** (`manifest.json`):
  - Added `https://2d.sparko.cz/*` to host permissions to enable API calls to the viewer domain
  - Registered new content script for `https://2d.sparko.cz/player*` pages
  
- **Updated webpack config** (`webpack.config.js`):
  - Added `viewer-content-script.js` as a build entry point

## Implementation Details
- The background service worker is used as a proxy for API calls since it has access to the user's Faceit session cookies via the `credentials: 'include'` option
- Match ID validation uses a strict regex pattern to ensure only valid Faceit match IDs trigger the auto-fetch
- Error handling is defensive: failures silently fall back to the viewer's native Faceit authentication dialog
- The implementation follows the same two-step API call pattern already used in other parts of the extension for consistency

https://claude.ai/code/session_014HGYBq7rFUJqEfZMnJe5Bw