### PR TITLE
Add background scripts configuration to manifest.json

### DIFF
--- a/browserplugin/faceit/manifest.json
+++ b/browserplugin/faceit/manifest.json
@@ -12,7 +12,8 @@
   },
   "description": "View CS2 demo replays in 2D directly from FACEIT match pages in single click.",
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "permissions": ["storage", "scripting"],
   "host_permissions": [

--- a/browserplugin/faceit/manifest.json
+++ b/browserplugin/faceit/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "FACEIT 2D Replay",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "sparko",
   "license": "MIT",
   "homepage_url": "https://2d.sparko.cz/",


### PR DESCRIPTION
## Summary
Updated the manifest.json configuration to include a `scripts` field in the background section alongside the existing `service_worker` field.

## Changes
- Added `"scripts": ["background.js"]` to the background configuration in manifest.json
- This provides backward compatibility or support for alternative background script loading mechanisms

## Implementation Details
The change maintains the existing `service_worker` field while adding a `scripts` array that references the same background.js file. This dual configuration may be necessary for compatibility across different browser versions or extension manifest versions that support different background script specifications.

https://claude.ai/code/session_01PstkPqZqyrRY7DX8pFLa1J