### PR TITLE
[WEB] remove lag during timeline scrubbing

### DIFF
--- a/web/src/Player/Player.js
+++ b/web/src/Player/Player.js
@@ -81,7 +81,8 @@ class Player {
             // console.log(this.interval)
             break;
           case MSG_PROGRESS_MOVE:
-            this.stop();
+            clearInterval(this.player);
+            this.playing = false;
             let round = this.rounds[this.playingRoundI];
             this.currentTickI = Math.round(
               round.ticksList.length * msg.progress

--- a/web/src/Player/panel/Timer.css
+++ b/web/src/Player/panel/Timer.css
@@ -20,7 +20,6 @@
 .timer-progress {
   background: linear-gradient(90deg, var(--TColor) 0%, rgba(199, 162, 71, 0.8) 100%);
   height: 100%;
-  transition: width 0.1s linear;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Improve timeline scrubbing responsiveness

Hi, I really like this tool, so I wanted to address one of my main issues with it :) These changes should make the timeline bar more responsive. Let me know what you think!

### Problem

Dragging along the round progress bar to seek through a round felt sluggish as there was a visible delay between cursor movement and the map updating player positions.

### Root cause

Two issues contributed to the lag:

1. **CSS transition on the progress bar** (`transition: width 0.1s linear`) — the bar visually lagged behind the cursor instead of tracking it instantly.
2. **Redundant re-render on every mouse-move pixel** — the `MSG_PROGRESS_MOVE` handler called `this.stop()`, which emitted a `MSG_PLAY_CHANGE` event. `Map2d` listens to this event and clears its shots/nade state via `setState`, causing an unnecessary render *before* the actual tick data render. This resulted in two renders per mouse-move instead of one.

### Changes

- **`Timer.css`**: Removed `transition: width 0.1s linear` from `.timer-progress` so the progress bar follows the cursor instantly.
- **`Player.js`**: Replaced `this.stop()` in the `MSG_PROGRESS_MOVE` handler with a direct `clearInterval()` + `this.playing = false`. This stops playback without emitting `MSG_PLAY_CHANGE`, eliminating the redundant `Map2d` re-render during scrubbing. The `MSG_PLAY_CHANGE` event is still correctly emitted for all other play/pause flows (toggle, round switch, speed change).
