### PR TITLE
Add support to load demos at valve demo urls directly

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -7,11 +7,17 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
+)
+
+var (
+	valveReplayHostPattern = regexp.MustCompile(`^replay[0-9]+\.valve\.net$`)
+	valveReplayPathPattern = regexp.MustCompile(`^/730/[0-9_]+\.dem\.bz2$`)
 )
 
 // allowedOrigin returns the value to use for Access-Control-Allow-Origin, or
@@ -39,7 +45,7 @@ func downloadHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	}
-	w.Header().Set("Access-Control-Expose-Headers", "X-Demo-Length")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Disposition, X-Demo-Length")
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -90,8 +96,7 @@ func downloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-	matchId := extractMatchId(demoUrl)
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.dem.zst"`, matchId))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, demoFilename(demoUrl)))
 	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
 		w.Header().Set("X-Demo-Length", contentLength)
 	}
@@ -138,11 +143,16 @@ func secureDemoUrl(urlParam string, isDev bool) (string, error) {
 		return "", fmt.Errorf("too long URL")
 	}
 
-	// In development mode, only allow http://localhost:8080
+	// Valve replay downloads require HTTP; strict host and path validation keeps
+	// this exception from turning the endpoint into an open proxy.
+	if isValveReplayURL(parsedURL) {
+		return parsedURL.String(), nil
+	}
+
 	if isDev {
 		if parsedURL.Scheme != "http" || parsedURL.Host != "localhost:8080" {
 			logger.Warn("Development mode: forbidden scheme or host", zap.String("scheme", parsedURL.Scheme), zap.String("host", parsedURL.Host))
-			return "", fmt.Errorf("development mode: only http://localhost:8080 is allowed, got: %s", parsedURL.String())
+			return "", fmt.Errorf("development mode: only http://localhost:8080 and validated Valve replay URLs are allowed, got: %s", parsedURL.String())
 		}
 		// In dev mode, return the URL as-is (already validated above)
 		return urlParam, nil
@@ -179,6 +189,33 @@ func secureDemoUrl(urlParam string, isDev bool) (string, error) {
 	}
 
 	return fmt.Sprintf("https://%s/cs2/%s.dem.zst?%s", allowedHosts[hostId], matchId, parsedURL.RawQuery), nil
+}
+
+func isValveReplayURL(parsedURL *url.URL) bool {
+	if parsedURL.User != nil || parsedURL.Port() != "" || parsedURL.RawQuery != "" {
+		return false
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return false
+	}
+
+	return valveReplayHostPattern.MatchString(strings.ToLower(parsedURL.Hostname())) &&
+		valveReplayPathPattern.MatchString(parsedURL.EscapedPath())
+}
+
+func demoFilename(demoURL string) string {
+	parsedURL, err := url.Parse(demoURL)
+	if err != nil {
+		return "demo.dem"
+	}
+
+	filename := path.Base(parsedURL.Path)
+	if filename == "." || filename == "/" || filename == "" {
+		return "demo.dem"
+	}
+
+	return filename
 }
 
 // extractMatchId extracts the match ID from a demo URL path

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestMatchId(t *testing.T) {
@@ -18,4 +20,51 @@ func TestMatchId(t *testing.T) {
 	testMatch("/cs2/1-e9789885-ebda-4f07-90de-8e38d73e174b-1-1.dem.zst?fshquiojfqos", expected)
 	testMatch("/cs2/1-e9789885-ebda-4f07-90de-8e38d73e174b-1-1.dem.zst", expected)
 	testMatch("/cs2/12-e9789885-ebda-4f07-90de-8e38d73e174b-1-12.dem.zst", "")
+}
+
+func TestSecureDemoURLAllowsValveReplayHosts(t *testing.T) {
+	urls := []string{
+		"http://replay392.valve.net/730/003831973762123694143_1839286853.dem.bz2",
+		"http://replay406.valve.net/730/003831784903821755073_2010893155.dem.bz2",
+	}
+
+	for _, isDev := range []bool{false, true} {
+		for _, demoURL := range urls {
+			t.Run(demoURL, func(t *testing.T) {
+				actual, err := secureDemoUrl(demoURL, isDev)
+				if err != nil {
+					t.Fatalf("secureDemoUrl() returned an error: %v", err)
+				}
+				if actual != demoURL {
+					t.Fatalf("secureDemoUrl() = %q, want %q", actual, demoURL)
+				}
+			})
+		}
+	}
+}
+
+func TestSecureDemoURLRejectsNonValveReplayURLs(t *testing.T) {
+	logger = zap.NewNop()
+
+	urls := []string{
+		"http://replay392.valve.net.evil.example/730/003831973762123694143_1839286853.dem.bz2",
+		"http://replay392.valve.net/730/not-a-demo.dem.bz2",
+		"http://replay392.valve.net:8080/730/003831973762123694143_1839286853.dem.bz2",
+		"http://replay392.valve.net/730/003831973762123694143_1839286853.dem.bz2?unexpected=query",
+	}
+
+	for _, demoURL := range urls {
+		t.Run(demoURL, func(t *testing.T) {
+			if _, err := secureDemoUrl(demoURL, false); err == nil {
+				t.Fatal("secureDemoUrl() accepted an unsafe Valve replay URL")
+			}
+		})
+	}
+}
+
+func TestDemoFilename(t *testing.T) {
+	filename := demoFilename("http://replay392.valve.net/730/003831973762123694143_1839286853.dem.bz2")
+	if filename != "003831973762123694143_1839286853.dem.bz2" {
+		t.Fatalf("demoFilename() = %q", filename)
+	}
 }

--- a/web/src/Index/Uploader/Uploader.css
+++ b/web/src/Index/Uploader/Uploader.css
@@ -16,6 +16,56 @@
   text-align: center;
 }
 
+.demo-url-divider {
+  color: var(--text-muted);
+  font-weight: 600;
+  margin: 1.25rem 0;
+  text-align: center;
+}
+
+.demo-url-form {
+  text-align: left;
+}
+
+.demo-url-form label {
+  color: var(--text-color);
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.demo-url-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.demo-url-controls input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--secondary-color);
+  border-radius: 6px;
+  color: var(--text-color);
+  flex: 1;
+  min-width: 0;
+  padding: 0.75rem;
+}
+
+.demo-url-controls button {
+  background: linear-gradient(135deg, #f4d03f 0%, var(--secondary-color) 100%);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  white-space: nowrap;
+}
+
+.demo-url-error {
+  color: #e74c3c;
+  margin: 0.5rem 0 0;
+}
+
 .upload-area {
   border: 3px dashed var(--secondary-color);
   border-radius: var(--border-radius);
@@ -153,5 +203,9 @@
   .upload-button {
     padding: 12px 25px;
     font-size: 1rem;
+  }
+
+  .demo-url-controls {
+    flex-direction: column;
   }
 }

--- a/web/src/Index/Uploader/Uploader.jsx
+++ b/web/src/Index/Uploader/Uploader.jsx
@@ -1,22 +1,62 @@
+import { useState } from "react";
 import { useLocation } from "preact-iso";
 import { useContext } from "react";
 import { DemoContext } from "../../context";
 import DemoUploadArea from "./DemoUploadArea";
+import "./Uploader.css";
 
 const Uploader = () => {
   const demoData = useContext(DemoContext);
   const { route } = useLocation();
+  const [demoUrl, setDemoUrl] = useState("");
+  const [urlError, setUrlError] = useState("");
 
   const handleFile = ({ filename, data }) => {
     demoData.setDemoData({ filename, data });
     route("/player");
   };
 
+  const handleDemoUrl = (event) => {
+    event.preventDefault();
+
+    try {
+      const parsedUrl = new URL(demoUrl);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        throw new Error("Unsupported protocol");
+      }
+
+      route(`/player?demourl=${encodeURIComponent(parsedUrl.toString())}`);
+    } catch {
+      setUrlError("Enter a valid http:// or https:// demo URL.");
+    }
+  };
+
   return (
-    <DemoUploadArea
-      onFile={handleFile}
-      subtext="Supports .dem, .dem.gz, .dem.zst and .dem.bz2 files up to 1GB"
-    />
+    <>
+      <DemoUploadArea
+        onFile={handleFile}
+        subtext="Supports .dem, .dem.gz, .dem.zst and .dem.bz2 files up to 1GB"
+      />
+      <div className="demo-url-divider">or</div>
+      <form className="demo-url-form" onSubmit={handleDemoUrl}>
+        <label htmlFor="demo-url">Load from demo URL</label>
+        <div className="demo-url-controls">
+          <input
+            id="demo-url"
+            type="url"
+            value={demoUrl}
+            onInput={(event) => {
+              setDemoUrl(event.currentTarget.value);
+              setUrlError("");
+            }}
+            placeholder="http://replay392.valve.net/730/….dem.bz2"
+            required
+          />
+          <button type="submit">Load demo</button>
+        </div>
+        {urlError && <p className="demo-url-error">{urlError}</p>}
+      </form>
+    </>
   );
 };
 

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -71,5 +71,11 @@ export default defineConfig(({ mode }) => {
     ],
     open: true,
     port: 3000,
+    server: {
+      // Route linked-demo downloads through the local Go server.
+      proxy: {
+        "/download": "http://localhost:8080",
+      },
+    },
   };
 });


### PR DESCRIPTION
Hey, amazing tool and thank you so much for creating it.

I don't play faceit (just normal premier), but I do review my demos on leetify, which easily shares the direct demo url from valve's servers. To save myself time from downloading the demo and uploading it, I added an additional textfield that accepts demo file urls from valve's servers.

<img width="1803" height="1242" alt="2026-07-18-23-59-26" src="https://github.com/user-attachments/assets/7d002218-c709-42e0-adbc-7e27767285b5" />
Try using a demo url such as: http://replay406.valve.net/730/003831784903821755073_2010893155.dem.bz2


Also supports from query params: http://localhost:5173/player?demourl=http%3A%2F%2Freplay406.valve.net%2F730%2F003831784903821755073_2010893155.dem.bz2

Totally understand if you wouldn't want this feature. Esp. if you don't play normal match making.

Thanks again!