### PR TITLE
Fix typo: Firefix -> Firefox in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A web-based application for visualizing Counter-Strike 2 (CS2) demo files in 2D.
  - [Live environment](https://2d.sparko.cz)
  - [Staging environment](https://dev.2d.sparko.cz)
  - [Chrome extension](https://chromewebstore.google.com/detail/kagfmemgilamfeoljmajifkbhfglebdb?utm_source=item-share-cb)
- - [Firefix extension](https://addons.mozilla.org/en-US/firefox/addon/faceit-2d-replay/)
+ - [Firefox extension](https://addons.mozilla.org/en-US/firefox/addon/faceit-2d-replay/)
 
 ## Project Components
 


### PR DESCRIPTION
## Summary
- Fixes a typo in README.md where the Firefox extension link was labeled "Firefix" instead of "Firefox"

## Test plan
- Docs-only change, no build/test required